### PR TITLE
Fix README legacy typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ zev-dashboard/
 ├── utils.py                  # Helper functions and mappings
 ├── styles.py                 # Centralized styling definitions for consistency
 ├── requirements.txt          # Python dependencies
-├── render.yaml               # (lagacy) Render deployment config
+├── render.yaml               # (legacy) Render deployment config.
 ├── .gitignore
 ├── README.md
 ├── assets/


### PR DESCRIPTION
## Summary
- fix small typo in README project structure

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8b6ebe18832186f2e4469fa1cda5